### PR TITLE
WIP: Enables travis ci cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
+cache: bundler
 rvm:
   - 2.0.0
   - 2.1.10
@@ -7,7 +8,9 @@ rvm:
   - 2.3.6
   - 2.4.3
   - 2.5.0
-install: BUNDLE_GEMFILE=gemfile bundle install
-script: BUNDLE_GEMFILE=gemfile bundle exec rake
+env:
+  TASK=bundle install
+  TASK=bundle exec rake
+script: BUNDLE_GEMFILE=gemfile $TASK
 notifications:
   email: false

--- a/gemfile.lock
+++ b/gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bun (1.1.0)
+    bun (1.2.0)
       bundler (~> 1.16)
       paint (~> 2.0)
       tty-spinner (~> 0.8)
@@ -11,28 +11,28 @@ GEM
   specs:
     coderay (1.1.2)
     diff-lcs (1.3)
-    method_source (0.9.0)
-    paint (2.0.1)
-    pry (0.11.3)
+    method_source (0.9.2)
+    paint (2.1.0)
+    pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rake (10.5.0)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
-    tty-cursor (0.5.0)
-    tty-spinner (0.8.0)
-      tty-cursor (>= 0.5.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    tty-cursor (0.6.1)
+    tty-spinner (0.9.0)
+      tty-cursor (~> 0.6.0)
 
 PLATFORMS
   ruby
@@ -44,4 +44,4 @@ DEPENDENCIES
   rspec (~> 3.7)
 
 BUNDLED WITH
-   1.16.1
+   1.16.6


### PR DESCRIPTION
Enabling the cache should make the builds faster (as long there's no change in gem versions).

This should be very straightforward but I was facing some problems on versions `2.3.6` and `2.4.3`, in which bundler could not resolve. So I deleted `gemfile.lock` and `bundle install`ed with ruby `2.0.0` (the min required ruby version). It seems that bun itself wasn't in 1.2. I hope this not bothers you.

Tell me if there's anything  to change! :grin: 